### PR TITLE
use s.waitForBoot instead of s.boot

### DIFF
--- a/Setup/Setup.scd
+++ b/Setup/Setup.scd
@@ -6,32 +6,33 @@ s.options.numBuffers = 1024 * 16;
 //increase the memory available to the server
 s.options.memSize = 8192 * 64;
 //boot the server
-s.boot;
-//display the oscilloscope
-s.scope;
-//start proxyspace
-p=ProxySpace.push(s);
-//start tempo clock
-p.makeTempoClock;
-//give proxyspace a tempo
-p.clock.tempo = 2;
-Task({
-	3.wait;
-	d = Dictionary.new;
-	d.add(\foldernames -> PathName(thisProcess.nowExecutingPath.dirname +/+ "../samples/set1").entries);
-	for (0, d[\foldernames].size-1,
-		{arg i; d.add(d[\foldernames][i].folderName -> d[\foldernames][i].entries.collect({
-			arg sf;
-			Buffer.read(s,sf.fullPath);
-		});
-	)});
-	("SynthDefs.scd").loadRelative;
-	//loads snippets from setup folder
-	("Snippets.scd").loadRelative;
-	//wait, because otherwise it won't work for some reason
-	3.wait;
-	//activate StageLimiter - Part of the BatLib quark
-	StageLimiter.activate;
-	"Setup done!".postln;
-}).start;
+s.waitForBoot({
+	//display the oscilloscope
+	s.scope;
+	//start proxyspace
+	p=ProxySpace.push(s);
+	//start tempo clock
+	p.makeTempoClock;
+	//give proxyspace a tempo
+	p.clock.tempo = 2;
+	Task({
+		3.wait;
+		d = Dictionary.new;
+		d.add(\foldernames -> PathName(thisProcess.nowExecutingPath.dirname +/+ "../samples/set1").entries);
+		for (0, d[\foldernames].size-1,
+			{arg i; d.add(d[\foldernames][i].folderName -> d[\foldernames][i].entries.collect({
+				arg sf;
+				Buffer.read(s,sf.fullPath);
+			});
+		)});
+		("SynthDefs.scd").loadRelative;
+		//loads snippets from setup folder
+		("Snippets.scd").loadRelative;
+		//wait, because otherwise it won't work for some reason
+		3.wait;
+		//activate StageLimiter - Part of the BatLib quark
+		StageLimiter.activate;
+		"Setup done!".postln;
+	}).start;
+})
 )


### PR DESCRIPTION
s.waitForBoot is more robust. at least on a headless raspberry pi setup s.boot simply wont work